### PR TITLE
feat: Initial Commit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "automerge": true,
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -1,0 +1,40 @@
+name: Bazel build
+
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  # typically used for bazel internal testing: changes outputRoot, sets idletimeout to ~15s
+  TEST_TMPDIR: /tmp/bazel
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+  push:
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    concurrency:
+       # trivial group in this shallow matrix but autocatches expansion
+       cancel-in-progress: true
+       group: ${{ github.ref }}-${{ github.workflow }}-${{ matrix.os }}-build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      -
+        uses: actions/checkout@v5.0.0
+        # https://github.com/bazelbuild/bazel/issues/11062
+      -
+        name: Basic Build
+        run: |
+          bazel build //...
+      -
+        name: Basic Test
+        run: bazel test //... --test_output=errors --test_summary=detailed
+      -
+        run: bazel shutdown

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bazel-*
+MODULE.bazel.lock

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:verify_archive.bzl", "verify_archive_test")
+
+buildifier(
+    name = "buildifier.fix",
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier(
+    name = "buildifier.check",
+    lint_mode = "warn",
+    lint_warnings = [
+        "-module-docstring",
+    ],
+    mode = "check",
+)
+
+alias (name="dnsmasq", actual = "@dnsmasq//:dnsmasq")
+pkg_tar(
+    name = "dnsmasq_tar",
+    srcs = [":dnsmasq"],
+    package_dir = "bin",
+)
+
+verify_archive_test(
+    name = "confirm_dnsmasq_short_path",
+    must_contain = [ "bin/dnsmasq" ],
+    tags = [ "no-cache" ],
+    target = ":dnsmasq_tar",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,27 @@
+module(
+    name = "rules_thirdparty",
+    version = "0.0.1",
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "2.21.1")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_foreign_cc", version = "0.13.0")
+bazel_dep(name = "rules_pkg", version = "1.1.0")
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
+
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name="dnsmasq",
+    build_file = "//thirdparty/dnsmasq:BUILD.dnsmasq.bazel",
+    #integrity = "sha256-9iJoKEizNnetsratCCZGGKKuCgHaSGqT/YzZEYaz0VM=",
+    sha256 = "f622682848b33677adb2b6ad08264618a2ae0a01da486a93fd8cd91186b3d153",
+    strip_prefix = "dnsmasq-2.91",
+    urls = [
+        "https://thekelleys.org.uk/dnsmasq/dnsmasq-2.91.tar.xz",
+    ],
+)
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # rules_thirdparty
+
 Some third-party stuff in Bazel.  Maybe.  Let's see.
+
+## dnsmasq
+(tested on darwin/arm64 with OSX-26.0)
+
+I first created this repo to work with Simon Kelley's dnsmasq in a cross-build environment, but I
+had such a problem getting logs or details from the foreign_cc build.
+
+Eventually, I saw that the make within the distributed Makefile was re-passing to $(MAKE) so I
+wrapped that in a log; this confirmed that the build was going (quickly!) and the failure was
+elsewhere.  Wrapping the `install` target helped show:
+
+1. PREFIX is getting a bazel sandbox path anyhow.  Although DESTDIR was intended to offer an
+    installroot capability, everyone follows Redhat's behavior of misusing PREFIX in automake
+    builds.  I dropped DESTDIR and simply overloaded PREFIX
+2. the install is working, and the PREFIX path is where `make()` expects it to be
+3. checking that target, `dnsmasq` is installed to PREFIX/sbin/dnsmasq (per the BINDIR defined in
+    Makefile) but `make()` is only looking in $PREFIX/bin/
+
+Redefining BINDIR in the BUILD.dnsmasq.bazel resolved.
+
+The debugging patch is in the thirdparty folder: `dnsmasq/Debug-the-build.patch`
+

--- a/thirdparty/dnsmasq/BUILD.dnsmasq.bazel
+++ b/thirdparty/dnsmasq/BUILD.dnsmasq.bazel
@@ -1,0 +1,29 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)
+make(
+  name = "_dnsmasq",
+  targets = [
+    # PREFIX is getting a value either way, so the proper DESTDIR is double-prefixing.
+    # Just (*sigh*) use prefix incorrectly as everyone does...
+    "PREFIX=$$INSTALLDIR$$ " +
+
+    # dnsmasq wants to build into ${PREFIX)/sbin, but make() only looks for ./bin
+    "BINDIR=$$INSTALLDIR$$/bin " +
+
+    "install",
+  ],
+  lib_source = ":all_files",
+  out_binaries = [ "dnsmasq" ],
+  tags = [ "no-cache" ],
+  visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "dnsmasq",
+    srcs = [":_dnsmasq" ],
+    output_group = "dnsmasq",
+    visibility = ["//visibility:public"],
+)

--- a/thirdparty/dnsmasq/Debug-the-build.patch
+++ b/thirdparty/dnsmasq/Debug-the-build.patch
@@ -1,0 +1,24 @@
+--- /private/var/tmp/_bazel_allanc/4e06a618cf97b780d0bf054c586e7f81/external/+_repo_rules+dnsmasq/Makefile	2025-03-14 08:09:35
++++ /Users/allanc/dnsmasq.Makefile	2025-09-21 15:31:12
+@@ -91,7 +91,7 @@
+  top="$(top)" \
+  build_cflags="$(version) $(dbus_cflags) $(idn2_cflags) $(idn_cflags) $(ct_cflags) $(lua_cflags) $(nettle_cflags) $(nft_cflags)" \
+  build_libs="$(dbus_libs) $(idn2_libs) $(idn_libs) $(ct_libs) $(lua_libs) $(sunos_libs) $(nettle_libs) $(gmp_libs) $(ubus_libs) $(nft_libs)" \
+- -f $(top)/Makefile dnsmasq 
++ -f $(top)/Makefile dnsmasq 2>&1 | tee /tmp/allanc-dnsmasq
+ 
+ mostly_clean :
+ 	rm -f $(BUILDDIR)/*.mo $(BUILDDIR)/*.pot 
+@@ -103,10 +103,12 @@
+ 	rm -f *~ contrib/*/*~ */*~
+ 
+ install : all
++	@echo 'Installing: DESTDIR=$(DESTDIR) PREFIX=$(PREFIX)' | tee -a /tmp/allanc-dnsmasq
+ 	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+ 	$(INSTALL) -d $(DESTDIR)$(MANDIR)/man8
+ 	$(INSTALL) -m 644 $(MAN)/dnsmasq.8 $(DESTDIR)$(MANDIR)/man8 
+ 	$(INSTALL) -m 755 $(BUILDDIR)/dnsmasq $(DESTDIR)$(BINDIR)
++	@echo 'Installed: DESTDIR=$(DESTDIR) PREFIX=$(PREFIX)' | tee -a /tmp/allanc-dnsmasq
+ 
+ all-i18n : $(BUILDDIR)
+ 	@cd $(BUILDDIR) && $(MAKE) \


### PR DESCRIPTION
This PR defines the build and check of Simon Kelley's `dnsmasq` as a precursor to a cross-compile of the same.

I often find myself searching for the definition of a `foreign_cc` so I figured I should define my own third-party lib.