### PR TITLE
fix: find/replace for repo rename

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 module(
-    name = "rules_thirdparty",
+    name = "bazel_thirdparty",
     version = "0.0.1",
 )
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rules_thirdparty
+# bazel_thirdparty
 
 Some third-party stuff in Bazel.  Maybe.  Let's see.
 


### PR DESCRIPTION
Not really a "ruleset", just some bazel wrap of third-party stuff.. so rename.