### PR TITLE
feat: see whether a hermetic compiler gives explicit CC AR LD envs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+common --enable_platform_specific_config
+build:linux --sandbox_add_mount_pair=/tmp
+build:macos --sandbox_add_mount_pair=/var/tmp

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -23,7 +23,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        # incompatible builds are flagged off with `target_comparible_with`
+        os: [ubuntu-24.04-arm, ubuntu-24.04, macos-15-intel, macos-latest]
 
     steps:
       -

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,7 +17,11 @@ buildifier(
     mode = "check",
 )
 
-alias (name="dnsmasq", actual = "@dnsmasq//:dnsmasq")
+alias(
+    name = "dnsmasq",
+    actual = "@dnsmasq//:dnsmasq",
+)
+
 pkg_tar(
     name = "dnsmasq_tar",
     srcs = [":dnsmasq"],
@@ -26,7 +30,7 @@ pkg_tar(
 
 verify_archive_test(
     name = "confirm_dnsmasq_short_path",
-    must_contain = [ "bin/dnsmasq" ],
-    tags = [ "no-cache" ],
+    must_contain = ["bin/dnsmasq"],
+    tags = ["no-cache"],
     target = ":dnsmasq_tar",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,17 +5,41 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "hermetic_cc_toolchain", version = "4.0.1")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.1", dev_dependency = True)
 
+toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
+toolchains.exec_platform(
+    arch = "amd64",
+    os = "linux",
+)
+toolchains.exec_platform(
+    arch = "arm64",
+    os = "linux",
+)
+toolchains.exec_platform(
+    arch = "amd64",
+    os = "macos",
+)
+toolchains.exec_platform(
+    arch = "arm64",
+    os = "macos",
+)
+use_repo(toolchains, "zig_sdk")
+
+register_toolchains(
+    "@zig_sdk//toolchain/...",
+    "@zig_sdk//libc_aware/toolchain/...",
+)
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name="dnsmasq",
+    name = "dnsmasq",
     build_file = "//thirdparty/dnsmasq:BUILD.dnsmasq.bazel",
     #integrity = "sha256-9iJoKEizNnetsratCCZGGKKuCgHaSGqT/YzZEYaz0VM=",
     sha256 = "f622682848b33677adb2b6ad08264618a2ae0a01da486a93fd8cd91186b3d153",
@@ -24,4 +48,3 @@ http_archive(
         "https://thekelleys.org.uk/dnsmasq/dnsmasq-2.91.tar.xz",
     ],
 )
-

--- a/thirdparty/dnsmasq/BUILD.dnsmasq.bazel
+++ b/thirdparty/dnsmasq/BUILD.dnsmasq.bazel
@@ -1,29 +1,33 @@
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
+
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
 )
+
 make(
-  name = "_dnsmasq",
-  targets = [
-    # PREFIX is getting a value either way, so the proper DESTDIR is double-prefixing.
-    # Just (*sigh*) use prefix incorrectly as everyone does...
-    "PREFIX=$$INSTALLDIR$$ " +
+    name = "_dnsmasq",
+    lib_source = ":all_files",
+    out_binaries = ["dnsmasq"],
+    tags = ["no-cache"],
 
-    # dnsmasq wants to build into ${PREFIX)/sbin, but make() only looks for ./bin
-    "BINDIR=$$INSTALLDIR$$/bin " +
+    # tries to link <net/ethernet.h> which is linux sysroot so needs porting to macos
+    target_compatible_with = ["@platforms//os:linux"],
+    targets = [
+        # PREFIX is getting a value either way, so the proper DESTDIR is double-prefixing.
+        # Just (*sigh*) use prefix incorrectly as everyone does...
+        "PREFIX=$$INSTALLDIR$$ " +
 
-    "install",
-  ],
-  lib_source = ":all_files",
-  out_binaries = [ "dnsmasq" ],
-  tags = [ "no-cache" ],
-  visibility = ["//visibility:public"],
+        # dnsmasq wants to build into ${PREFIX)/sbin, but make() only looks for ./bin
+        "BINDIR=$$INSTALLDIR$$/bin " +
+        "install",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "dnsmasq",
-    srcs = [":_dnsmasq" ],
+    srcs = [":_dnsmasq"],
     output_group = "dnsmasq",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
I found in some instances of `rules_foreign_cc`, the implicit CC, AR, LD would result in a `libtool ar` being given as the value for `$AR`, but that means `AR=libtool`, hilarity followed closely.  And clown cars.

My using a hermetic CC, I get hermeticity -- its own reward -- plus an explicit AR, CC, LD that seemed to help in the one-off experiment of `rules_foreign_cc` with ISC DHCP.
